### PR TITLE
Change in the Log about the address use for the UE.

### DIFF
--- a/src/pgw/pgw_context.c
+++ b/src/pgw/pgw_context.c
@@ -915,7 +915,9 @@ pgw_sess_t *pgw_sess_add(
     else
         ogs_assert_if_reached();
 
-    ogs_info("UE IPv4:[%s] IPv6:[%s]",
+    ogs_info("UE IMSI:[%s] APN:[%s] IPv4:[%s] IPv6:[%s]",
+	    sess->imsi_bcd,
+	    apn,
             sess->ipv4 ?  INET_NTOP(&sess->ipv4->addr, buf1) : "",
             sess->ipv6 ?  INET6_NTOP(&sess->ipv6->addr, buf2) : "");
 


### PR DESCRIPTION
Hello,

I made some changes to increase the log information file from PGW, now it's saving information about what IMSI get the address.

Now, when an user connect the information about it is saved in the log:

05/02 12:53:19.082: [pgw] INFO: UE IMSI:[724120000000001] APN:[internet] IPv4:[192.168.0.2] IPv6:[2001:db8:cofe::2] (pgw_context.c:922).

Thanks 

Romeu Medeiros