### PR TITLE
freeDiameter: Fix compilation on Linux without SCTP_SEND_FAILED_EVENT

### DIFF
--- a/lib/asn1c/Makefile.am
+++ b/lib/asn1c/Makefile.am
@@ -1132,7 +1132,6 @@ libasn1c_la_SOURCES= \
     $(NULL)
 
 libasn1c_la_DEPENDENCIES = \
-	@OGSCORE_LIBS@ \
     $(top_srcdir)/lib/base/libbase.la \
 	$(NULL)
 

--- a/lib/base/Makefile.am
+++ b/lib/base/Makefile.am
@@ -9,7 +9,6 @@ libbase_la_SOURCES = \
 	$(NULL)
 
 libbase_la_DEPENDENCIES = \
-	@OGSCORE_LIBS@ \
 	$(NULL)
 
 libbase_la_LIBADD = \

--- a/lib/fd/Makefile.am
+++ b/lib/fd/Makefile.am
@@ -32,7 +32,6 @@ libfd_la_SOURCES = \
 	$(NULL)
 
 libfd_la_DEPENDENCIES = \
-	@OGSCORE_LIBS@ \
     $(top_srcdir)/lib/@FREEDIAMETER_DIR@/libfdcore/libfdcore.la \
     $(top_srcdir)/lib/@FREEDIAMETER_DIR@/libfdproto/libfdproto.la \
     $(top_srcdir)/lib/base/libbase.la \

--- a/lib/freeDiameter-1.2.1/libfdcore/sctp.c
+++ b/lib/freeDiameter-1.2.1/libfdcore/sctp.c
@@ -48,7 +48,8 @@
 /* #define OLD_SCTP_SOCKET_API */
 
 /* Automatically fallback to old API if some of the new symbols are not defined */
-#if (!defined(SCTP_CONNECTX_4_ARGS) || (!defined(SCTP_RECVRCVINFO)) || (!defined(SCTP_SNDINFO))) 
+#if (!defined(SCTP_CONNECTX_4_ARGS) || (!defined(SCTP_RECVRCVINFO)) || (!defined(SCTP_SNDINFO)) || \
+    (!defined(SCTP_SEND_FAILED_EVENT)) || (!defined(SCTP_NOTIFICATIONS_STOPPED_EVENT)) )
 # define OLD_SCTP_SOCKET_API
 #endif
 

--- a/lib/gtp/Makefile.am
+++ b/lib/gtp/Makefile.am
@@ -25,7 +25,6 @@ libgtp_la_SOURCES = \
 	$(NULL)
 
 libgtp_la_DEPENDENCIES = \
-	@OGSCORE_LIBS@ \
     $(top_srcdir)/lib/base/libbase.la \
 	$(NULL)
 

--- a/lib/nas/Makefile.am
+++ b/lib/nas/Makefile.am
@@ -23,7 +23,6 @@ libnas_la_SOURCES = \
 	$(NULL)
 
 libnas_la_DEPENDENCIES = \
-	@OGSCORE_LIBS@ \
     $(top_srcdir)/lib/base/libbase.la \
 	$(NULL)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,7 +7,6 @@ noinst_LTLIBRARIES = libmme.la libhss.la libsgw.la libpgw.la libpcrf.la libepc.l
 libmme_la_SOURCES = mme.c
 libmme_la_DEPENDENCIES = \
 	$(top_srcdir)/src/mme/libmme.la \
-	@OGSCRYPT_LIBS@ \
 	$(NULL)
 libmme_la_LIBADD = \
 	$(top_srcdir)/src/mme/libmme.la \
@@ -17,7 +16,6 @@ libmme_la_LIBADD = \
 libhss_la_SOURCES = hss.c
 libhss_la_DEPENDENCIES = \
 	$(top_srcdir)/src/hss/libhss.la \
-	@OGSCRYPT_LIBS@ \
 	$(NULL)
 libhss_la_LIBADD = \
 	$(top_srcdir)/src/hss/libhss.la \
@@ -55,7 +53,6 @@ libepc_la_DEPENDENCIES = \
     $(top_srcdir)/src/sgw/libsgw.la \
     $(top_srcdir)/src/pgw/libpgw.la \
     $(top_srcdir)/src/pcrf/libpcrf.la \
-	@OGSCRYPT_LIBS@ \
 	$(NULL)
 libepc_la_LIBADD = \
     $(top_srcdir)/src/mme/libmme.la \

--- a/src/app/Makefile.am
+++ b/src/app/Makefile.am
@@ -14,7 +14,6 @@ libapp_la_LIBADD = \
 	$(NULL)
  
 libapp_la_DEPENDENCIES = \
-	@OGSCORE_LIBS@ \
 	$(NULL)
 
 AM_CPPFLAGS = \


### PR DESCRIPTION
The fallback to the old SCTP API must be made if either SCTP_SEND_FAILED_EVENT
or SCTP_NOTIFICATIONS_STOPPED_EVENT are undeclared.

This fixes building nextepc on e.g. Debian unstable.

Closes: #208