### PR TITLE
freeDiameter: Use SCTP-only by default, not TCP-only

### DIFF
--- a/support/freeDiameter/hss.conf.in
+++ b/support/freeDiameter/hss.conf.in
@@ -46,12 +46,12 @@ Realm = "localdomain";
 
 # Disable use of TCP protocol (only listen and connect over SCTP)
 # Default : TCP enabled
-#No_TCP;
+No_TCP;
 
 # Disable use of SCTP protocol (only listen and connect over TCP)
 # Default : SCTP enabled
 #No_SCTP;
-No_SCTP;
+#No_SCTP;
 # This option is ignored if freeDiameter is compiled with DISABLE_SCTP option.
 
 # Prefer TCP instead of SCTP for establishing new connections.

--- a/support/freeDiameter/mme.conf.in
+++ b/support/freeDiameter/mme.conf.in
@@ -46,12 +46,12 @@ Realm = "localdomain";
 
 # Disable use of TCP protocol (only listen and connect over SCTP)
 # Default : TCP enabled
-#No_TCP;
+No_TCP;
 
 # Disable use of SCTP protocol (only listen and connect over TCP)
 # Default : SCTP enabled
 #No_SCTP;
-No_SCTP;
+#No_SCTP;
 # This option is ignored if freeDiameter is compiled with DISABLE_SCTP option.
 
 # Prefer TCP instead of SCTP for establishing new connections.

--- a/support/freeDiameter/pcrf.conf.in
+++ b/support/freeDiameter/pcrf.conf.in
@@ -46,12 +46,12 @@ Realm = "localdomain";
 
 # Disable use of TCP protocol (only listen and connect over SCTP)
 # Default : TCP enabled
-#No_TCP;
+No_TCP;
 
 # Disable use of SCTP protocol (only listen and connect over TCP)
 # Default : SCTP enabled
 #No_SCTP;
-No_SCTP;
+#No_SCTP;
 # This option is ignored if freeDiameter is compiled with DISABLE_SCTP option.
 
 # Prefer TCP instead of SCTP for establishing new connections.

--- a/support/freeDiameter/pgw.conf.in
+++ b/support/freeDiameter/pgw.conf.in
@@ -46,12 +46,12 @@ Realm = "localdomain";
 
 # Disable use of TCP protocol (only listen and connect over SCTP)
 # Default : TCP enabled
-#No_TCP;
+No_TCP;
 
 # Disable use of SCTP protocol (only listen and connect over TCP)
 # Default : SCTP enabled
 #No_SCTP;
-No_SCTP;
+#No_SCTP;
 # This option is ignored if freeDiameter is compiled with DISABLE_SCTP option.
 
 # Prefer TCP instead of SCTP for establishing new connections.


### PR DESCRIPTION
The existing freeDiameter default config files for HSS, MME, PCRF and PGW
disabled SCTP and enabled TCP.  This is not in compliance with
3GPP TS 29.272 secition 7.1.5 which clearly states:
	"Diameter messages over the S6a, S6d, S13 and S13' interfaces shall
	 make use of SCTP IETF RFC 4960 [14]"