### PR TITLE
Fix buffer length calculation in s1ap_copy_ie

### DIFF
--- a/src/mme/s1ap-conv.c
+++ b/src/mme/s1ap-conv.c
@@ -190,7 +190,7 @@ int s1ap_copy_ie(const asn_TYPE_descriptor_t *td, void *src, void *dst)
     }
 
     dec_ret = aper_decode(NULL, td, (void **)&dst,
-            buffer, (enc_ret.encoded >> 3), 0, 0);
+            buffer, ((enc_ret.encoded + 7) / 8), 0, 0);
 
     if (dec_ret.code != RC_OK) {
         ogs_error("aper_decode() failed[%d]", dec_ret.code);

--- a/tests/unit/crash-test.c
+++ b/tests/unit/crash-test.c
@@ -375,9 +375,7 @@ abts_suite *test_crash(abts_suite *suite)
     suite = ADD_SUITE(suite)
 
     abts_run_test(suite, test1_func, NULL);
-#if 0
     abts_run_test(suite, test2_func, NULL);
-#endif
     abts_run_test(suite, test3_func, NULL);
 
     return suite;


### PR DESCRIPTION
The aper_encode function returns the number of encoded bits and when
converting to bytes we should round up or use the ((.encoded + 7) / 8)
formula as described in per_encoder.h

Fixes: #257